### PR TITLE
Escaped path in CLI script

### DIFF
--- a/src/pylode/bin/pylode
+++ b/src/pylode/bin/pylode
@@ -1,4 +1,4 @@
 #!/bin/bash
 PARENT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 GRANDPARENT=`dirname $PARENT`
-python3 $GRANDPARENT/cli.py "$@"
+python3 "$GRANDPARENT/cli.py" "$@"


### PR DESCRIPTION
This is required to handle executing from paths with spaces in them (as is common, e.g., on Windows machines).