### PR TITLE
Allow use of pyinstaller for windows binary of pylode

### DIFF
--- a/src/pylode/makedocco.py
+++ b/src/pylode/makedocco.py
@@ -6,7 +6,10 @@ import requests
 import collections
 import dateutil.parser
 from jinja2 import Environment, FileSystemLoader
-
+from rdflib import plugin
+from rdflib.plugin import register, Serializer
+from rdflib_jsonld import serializer
+register('json-ld', Serializer, 'rdflib_jsonld.serializer', 'JsonLDSerializer')
 
 class MakeDocco:
     def __init__(self, outputformat='html'):

--- a/src/pylode/pylode-cli.spec
+++ b/src/pylode/pylode-cli.spec
@@ -1,4 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
+## run `pyinstaller pylode-cli.spec` to create `dist/pylode.exe` dist
+## note it requires pywin32
 
 block_cipher = None
 

--- a/src/pylode/pylode-cli.spec
+++ b/src/pylode/pylode-cli.spec
@@ -1,0 +1,37 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(['cli.py'],
+             pathex=['.'],
+             binaries=[],
+             datas=[
+                       ('templates/*.html','templates'),
+                       ('style/*.css','style')
+                    ],
+             hiddenimports=['rdflib.plugins',
+                             'rdflib','urllib3','rdflib_jsonld'],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='pylode',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          console=True )

--- a/src/pylode/pylode-cli.spec
+++ b/src/pylode/pylode-cli.spec
@@ -9,7 +9,7 @@ a = Analysis(['cli.py'],
              pathex=['.'],
              binaries=[],
              datas=[
-                       ('templates/*.html','templates'),
+                       ('templates/*.*','templates'),
                        ('style/*.css','style')
                     ],
              hiddenimports=['rdflib.plugins',


### PR DESCRIPTION
This PR provides the spec file for use in pyinstaller for outputing a windows binary of pylode.

makedocco needed to register `json-ld` as a plugin for pyinstaller to pick it up.