### PR TITLE
Changed markdown heading ids in order to be consistent with the ids o…

### DIFF
--- a/pylode/templates/class.md
+++ b/pylode/templates/class.md
@@ -1,4 +1,4 @@
-### {{ title }} <sup>c</sup>
+### {{ title }}
 Property | Value
 --- | ---
 IRI | `{{ uri }}`

--- a/pylode/templates/document.md
+++ b/pylode/templates/document.md
@@ -5,7 +5,7 @@
 
 ## Legend
 * Classes: c
-* Object Properties :op
+* Object Properties: op
 * Functional Properties: fp
 * Data Properties: dp
 * Annotation Properties: dp

--- a/pylode/templates/metadata.md
+++ b/pylode/templates/metadata.md
@@ -49,7 +49,7 @@ Markdown documentation created by [pyLODE](http://github.com/rdflib/pyLODE)
 {%- endif %}
 * **Imports**
 {%- for import in imports %}
-  * {{ import }}  
+  * {{ import }}
 {%- endfor %}
 {%- endif %}
 {%- if rights is not none and license is not none %}
@@ -84,29 +84,29 @@ Markdown documentation created by [pyLODE](http://github.com/rdflib/pyLODE)
 
 ## Table of Contents
 {%- if has_classes %}
-1. [Classes](#classes)  
+1. [Classes](#Classes)
 {%- endif %}
 {%- if has_ops %}
-1. [Object Properties](#objectproperties)  
+1. [Object Properties](#Object-Properties)
 {%- endif %}
 {%- if has_fps %}
-1. [Functional Properties](#functionalproperties)  
+1. [Functional Properties](#Functional-Properties)
 {%- endif %}
 {%- if has_dps %}
-1. [Datatype Properties](#datatypeproperties)  
+1. [Datatype Properties](#Datatype-Properties)
 {%- endif %}
 {%- if has_aps %}
-1. [Annotation Properties](#annotationproperties)  
+1. [Annotation Properties](#Annotation-Properties)
 {%- endif %}
 {%- if has_ps %}
-1. [Properties](#properties)  
+1. [Properties](#Properties)
 {%- endif %}
 {%- if has_nis %}
-1. [Named Individuals](#namedindividuals)  
+1. [Named Individuals](#Named-individuals)
 {%- endif %}
-1. [Namespaces](#namespaces)  
+1. [Namespaces](#Namespaces)
 
 
 ## Overview
 
-**Figure 1:** Ontology overview  
+**Figure 1:** Ontology overview

--- a/pylode/templates/properties.md
+++ b/pylode/templates/properties.md
@@ -1,7 +1,7 @@
 {%- if op_instances|length > 0 %}
 ## Object Properties
 {%- for p in op_instances %}
-[{{ p[0] }}]({{ p[1] }}), 
+[{{ p[0] }}](#{{ p[1] }}),
 {%- endfor %}
 {%- for p in op_instances %}
 {{ p[2]|safe }}
@@ -10,7 +10,7 @@
 {%- if fp_instances|length > 0 %}
 ## Functional Properties
 {%- for p in fp_instances %}
-[{{ p[0] }}]({{ p[1] }}), 
+[{{ p[0] }}](#{{ p[1] }}),
 {%- endfor %}
 {%- for p in fp_instances %}
 {{ p[2]|safe }}
@@ -19,7 +19,7 @@
 {%- if dp_instances|length > 0 %}
 ## Datatype Properties
 {%- for p in dp_instances %}
-[{{ p[0] }}]({{ p[1] }}), 
+[{{ p[0] }}](#{{ p[1] }}),
 {%- endfor %}
 {%- for p in dp_instances %}
 {{ p[2]|safe }}
@@ -28,7 +28,7 @@
 {%- if ap_instances|length > 0 %}
 ## Annotation Properties
 {%- for p in ap_instances %}
-[{{ p[0] }}]({{ p[1] }}), 
+[{{ p[0] }}](#{{ p[1] }}),
 {%- endfor %}
 {%- for p in ap_instances %}
 {{ p[2]|safe }}
@@ -37,7 +37,7 @@
 {%- if p_instances|length > 0 %}
 ## Properties
 {%- for p in p_instances %}
-[{{ p[0] }}]({{ p[1] }}), 
+[{{ p[0] }}](#{{ p[1] }}),
 {%- endfor %}
 {%- for p in p_instances %}
 {{ p[2]|safe }}

--- a/pylode/templates/property.md
+++ b/pylode/templates/property.md
@@ -1,5 +1,5 @@
 []({{ fid }})
-### {{ title }} <sup>{{ property_type }}</sup>
+### {{ title }}
 Property | Value
 --- | ---
 IRI | `{{ uri }}`


### PR DESCRIPTION
Changed markdown heading ids in order to be consistent with the ids of classes and properties (important for generating heading ids with tools such as markdown-it). Also, corrected missing # in link in properties. Finally, removed the SUP tag since it conflits with generating the id of the heading with tools such as markdown-it-anchor.

Solves the issue of bad anchors in markdown format.  #53 
