### PR TITLE
Fix gunicorn issues and subrocess return value such that client can now obtain the HTML response.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,13 +171,12 @@ An online API to access pyLODE is now available in test mode at https://kurrawon
 Local server - Falcon
 ---------------------
 You can run pyLODE using your own, local, HTTP server like this:
-```
-gunicorn server:api
-```
+::
+        cd pylode && gunicorn --chdir /home/cor-admin1/pyLODE/pylode server:api
+
 Then, in another terminal:
-```
-curl localhost:8000/lode?url=http://sweetontology.net/sweetAll.ttl
-```
+::
+        curl localhost:8000/lode?url=http://sweetontology.net/sweetAll.ttl
 
 Windows - create EXE from source
 --------------------------------

--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ Local server - Falcon
 ---------------------
 You can run pyLODE using your own, local, HTTP server like this:
 ::
-        cd pylode && gunicorn --chdir /home/cor-admin1/pyLODE/pylode server:api
+        cd pylode && gunicorn --chdir /path/to/pyLODE/pylode server:api
 
 Then, in another terminal:
 ::

--- a/pylode/cli.py
+++ b/pylode/cli.py
@@ -132,12 +132,12 @@ def main(args=None):
         # args are present so getting RDF from input file or uri into an rdflib Graph
         if args.inputfile:
             h = MakeDocco(
-                input_data_file=args.inputfile.name,
+                input_data_file=args.inputfile,
                 outputformat=args.outputformat,
                 profile=args.profile
             )
         elif args.url:
-            h = MakeDocco(input_uri=args.url.name, outputformat=args.outputformat, profile=args.profile)
+            h = MakeDocco(input_uri=args.url, outputformat=args.outputformat, profile=args.profile)
         else:
             # we have neither an input file or a URI supplied
             parser.error(

--- a/pylode/server.py
+++ b/pylode/server.py
@@ -7,8 +7,8 @@ class DocResource:
         """Handles GET requests"""
         url = req.get_param("url")
         if url is not None:
-            cmd = "cd ./bin && ./pylode -u {url} -c true".format(url=url)
-            subprocess.call(cmd, shell=True)
+            cmd = "cd ./bin && ./pylode.sh -u {url} -c true".format(url=url)
+            resp.body = subprocess.check_output(cmd, shell=True)
             resp.set_header("Powered-By", "Falcon")
             resp.status = falcon.HTTP_200
 


### PR DESCRIPTION
Hi @nicholascar 
This is a small PR which cleans up some issues with regards to running pyLODE (via Falcon) as a service. 
This now works perfectly.
I am standing up pyLODE on the ESIP COR machine at cor.esipfed.org/pylode so it will be available probably later today. If you could review and merge this request it would be appreciated. 