### PR TITLE
Establish correct content-type response header for GET on resources

### DIFF
--- a/pylode/server.py
+++ b/pylode/server.py
@@ -10,7 +10,7 @@ class DocResource:
             cmd = "cd ./bin && ./pylode.sh -u {url} -c true".format(url=url)
             resp.body = subprocess.check_output(cmd, shell=True)
             resp.set_header("Powered-By", "Falcon")
-            resp.set_header("content-type",	"text/html")
+            resp.set_header("content-type", "text/html")
             resp.status = falcon.HTTP_200
 
 

--- a/pylode/server.py
+++ b/pylode/server.py
@@ -10,6 +10,7 @@ class DocResource:
             cmd = "cd ./bin && ./pylode.sh -u {url} -c true".format(url=url)
             resp.body = subprocess.check_output(cmd, shell=True)
             resp.set_header("Powered-By", "Falcon")
+            resp.set_header("content-type",	"text/html")
             resp.status = falcon.HTTP_200
 
 


### PR DESCRIPTION
Hi @nicholascar this is a trivial fix which merely introduces the expected `content-type` response header for GET requests on DocResource.
Absence of this response header resulted in the content being returned as `application/json` in the response header.
One-line fix.