### PR TITLE
ISSUE-80 Embed Google Analytics in pyLODE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+ARG PYTHON_VERSION=3.8-slim
+FROM python:$PYTHON_VERSION
+
+MAINTAINER pyLODE Developers <https://github.com/RDFLib/pyLODE/graphs/contributors>
+
+USER root
+
+RUN apt-get update && \
+	apt-get upgrade -y --allow-downgrades --allow-remove-essential --allow-change-held-packages
+
+#copy the current directory contents
+ADD . /app
+
+WORKDIR /app
+
+#install pyLODE from source, ensures we always use the latest development branch
+RUN python3 setup.py install
+
+RUN cd ./pylode
+
+EXPOSE 8000
+
+CMD ["gunicorn"  , "-b", "0.0.0.0:8000", "--chdir", "/app/pylode", "server:api"]

--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,29 @@ Online Service
 --------------
 An online API to access pyLODE is now available in test mode at https://kurrawong.net/pylode-online.
 
+Docker
+------
+Install locally by first building the container
+
+::
+
+    docker build -t pylode:latest --build-arg PYTHON_VERSION=3.8-slim .
+
+Then run the container
+
+::
+
+    docker run -it -d -p 8000:8000 -e GTAGID=${Google TagID} pylode
+
+N.B. The Google TagID is NOT required unless Google Analytics is required. 
+It looks as follows `GTAGID=UA-168806395-1`.
+
+You can now access the service on localhost
+
+::
+
+    curl localhost:8000/lode?url=http://sweetontology.net/sweetAll.ttl
+
 Local server - Falcon
 ---------------------
 You can run pyLODE using your own, local, HTTP server like this:
@@ -226,6 +249,7 @@ As per instructions for PyInstaller use on Windows, you can rebuild the file ``p
 Linux
 -----
 In ``pylode/bin/``, there is a shell script ``pylode.sh``. You can run this on the command line. It just pushes queries to the Python command line ``cli.py``.
+
 
 What pyLODE understands
 =======================

--- a/pylode/server.py
+++ b/pylode/server.py
@@ -1,4 +1,7 @@
+from bs4 import BeautifulSoup as Soup
+
 import falcon
+import os
 import subprocess
 
 
@@ -12,13 +15,26 @@ class DocResource:
             # remove Overview image placeholder, if present
             raw_html = subprocess.check_output(cmd, shell=True)
             processed_html = raw_html.decode().replace(
-                '<section id="overview">', '<section id="overview" style="display:none;">').encode()
-            resp.body = processed_html
+                '<section id="overview">', '<section id="overview" style="display:none;">')
+            soup = Soup(processed_html, features="html.parser")
+            if os.getenv('GTAGID') is not None:
+                tag = os.getenv('GTAGID')
+                title = soup.find('title')
+                async_tag = soup.new_tag("script")
+                async_tag['async src'] = "https://www.googletagmanager.com/gtag/js?id=%s" % tag
+                title.insert_after(async_tag)
+                gtag = soup.new_tag('script')
+                gtag.string = """window.dataLayer = window.dataLayer || [];\n
+                      function gtag(){dataLayer.push(arguments);}\n
+                      gtag('js', new Date());\n
+                      gtag('config', '%s');\n""" % tag
+                async_tag.insert_after(gtag)
+            resp.body = soup
 
             resp.set_header("Powered-By", "Falcon")
             resp.set_header("content-type", "text/html")
             resp.status = falcon.HTTP_200
 
 
-api = falcon.API()
+api = falcon.App()
 api.add_route("/lode", DocResource())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 argparse
+beautifulsoup4
 falcon
 gunicorn
 jinja2


### PR DESCRIPTION
This PR addresses #80 

It also adds a Dockefile and augments the documentation describing how one would pass the Google Analytics tracking ID as a Docker runtime environment variable. 

The Docker build makes it very easy to install pyLODE now... merely 2 commands. 

```
docker build -t pylode:latest --build-arg PYTHON_VERSION=3.8-slim .
docker run -it -d -p 8000:8000 -e GTAGID=UA-168806395-1 pylode
```
Note, the `-e GTAGID=UA-168806395-1` which is a dummy tracker...