### PR TITLE
ISSUE-87 Internal Server Error when processing resource

### DIFF
--- a/pylode/server.py
+++ b/pylode/server.py
@@ -7,6 +7,7 @@ class DocResource:
         """Handles GET requests"""
         url = req.get_param("url")
         if url is not None:
+            raise Exception(url)
             cmd = "cd ./bin && ./pylode.sh -u {url} -c true".format(url=url)
 
             # remove Overview image placeholder, if present


### PR DESCRIPTION
OK this issue is intriguing :)

The PR is draft and DOES not fix the issue reported at #87. Here are my findings

With the patch applied, when I submit  resource as follows
```
curl "localhost:8000/lode?url=http://cor.esipfed.org/ont/api/v0/ont?iri=http://purl.dataone.org/provone/2015/01/15/ontology#"
```
The falcon server throw the folowing
```
[2020-08-14 13:49:35 -0700] [88703] [ERROR] Error handling request /lode?url=http://cor.esipfed.org/ont/api/v0/ont?iri=http://purl.dataone.org/provone/2015/01/15/ontology
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/sync.py", line 176, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/usr/local/lib/python3.7/site-packages/falcon/api.py", line 269, in __call__
    responder(req, resp, **params)
  File "/Users/lmcgibbn/Downloads/pyLODE/pylode/server.py", line 10, in on_get
    raise Exception(url)
Exception: http://cor.esipfed.org/ont/api/v0/ont?iri=http://purl.dataone.org/provone/2015/01/15/ontology
```
Note, the URI with absent trailing `#`

When I encode the trailing `#` and try again
```
curl "localhost:8000/lode?url=http://cor.esipfed.org/ont/api/v0/ont?iri=http://purl.dataone.org/provone/2015/01/15/ontology%23"
...
[2020-08-14 13:50:29 -0700] [88703] [ERROR] Error handling request /lode?url=http://cor.esipfed.org/ont/api/v0/ont?iri=http://purl.dataone.org/provone/2015/01/15/ontology%23
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/sync.py", line 176, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/usr/local/lib/python3.7/site-packages/falcon/api.py", line 269, in __call__
    responder(req, resp, **params)
  File "/Users/lmcgibbn/Downloads/pyLODE/pylode/server.py", line 10, in on_get
    raise Exception(url)
Exception: http://cor.esipfed.org/ont/api/v0/ont?iri=http://purl.dataone.org/provone/2015/01/15/ontology#
```
Is this an issue with Falcon... ?