### PR TITLE
Removed <pre> tags for the example property in ontdoc template.

### DIFF
--- a/pylode/templates/ontdoc/property.html
+++ b/pylode/templates/ontdoc/property.html
@@ -53,9 +53,7 @@
             <tr>
                 <th>Example</th>
                 <td>
-                    <pre>
-                      {{ example }}
-                    </pre>
+                    {{ example }}
                 </td>
             </tr>
             {%- endif %}


### PR DESCRIPTION
Removed <pre> tags for the example property. The preformatted tag respects whitespace, which I don't think is intended here. It ruins the formatting of the HTML document.