### PR TITLE
Fixed OWL properties only render description values with the rdfs:comment property and not the other annotation properties. 

### DIFF
--- a/pylode/profiles/ontdoc.py
+++ b/pylode/profiles/ontdoc.py
@@ -652,7 +652,7 @@ class OntDoc(BaseProfile):
                 if p == RDFS.label:
                     self.PROPERTIES[prop]["title"] = str(o)
 
-                if p == RDFS.comment:
+                if p == DCTERMS.description:
                     self.PROPERTIES[prop]["description"] = str(o)
 
                 if p == SKOS.scopeNote:


### PR DESCRIPTION
See issue https://github.com/RDFLib/pyLODE/issues/92.