### PR TITLE
Fixed errors related to Unicode characters

### DIFF
--- a/pylode/common.py
+++ b/pylode/common.py
@@ -175,7 +175,7 @@ class MakeDocco:
         if destination is not None:
             doc = p.generate_document()
             try:
-                with open(destination, "w") as f:
+                with open(destination, "w", encoding="utf8") as f:
                     f.write(doc)
             except Exception as e:
                 print(e)


### PR DESCRIPTION
Hi,
These days I had to use your wonderful pyLODE and I needed to fix a problem related to unicode characters, since my ontology uses both English and Italian (and accented characters).

It was a quick fix; it seems to solve the problem for me, and it should also solve any problem like those similar to issue #110 (I tested the attached ontology, to be sure).

I hope that this small contribution can be of any use to you.