### PR TITLE
Fix empty NI list in OntDoc template

### DIFF
--- a/pylode/templates/ontdoc/document.html
+++ b/pylode/templates/ontdoc/document.html
@@ -22,9 +22,7 @@
   {{ metadata|safe }}
   {{ classes|safe }}
   {{- properties|safe }}
-  {% if named_individuals|length > 0 %}
   {{ named_individuals|safe }}
-  {% endif %}
   {{ namespaces|safe }}
   <section id="legend">
       <h2>Legend</h2>

--- a/pylode/templates/ontdoc/named_individuals.html
+++ b/pylode/templates/ontdoc/named_individuals.html
@@ -1,11 +1,13 @@
-<section id="namedindividuals">
-    <h2>Named Individuals <span style="float:right; font-size:smaller;"><a href="">&uparrow;</a></span></h2>
-    <ul class="hlist">
-        {%- for fid in fids %}
-        <li><a href="#{{ fid[0] }}">{{ fid[1] }}</a></li>
+{% if named_individuals|length > 0 %}
+    <section id="namedindividuals">
+        <h2>Named Individuals <span style="float:right; font-size:smaller;"><a href="">&uparrow;</a></span></h2>
+        <ul class="hlist">
+            {%- for fid in fids %}
+            <li><a href="#{{ fid[0] }}">{{ fid[1] }}</a></li>
+            {%- endfor %}
+        </ul>
+        {%- for ni in named_individuals %}
+            {{ ni|safe }}
         {%- endfor %}
-    </ul>
-    {%- for ni in named_individuals %}
-    {{ ni|safe }}
-    {%- endfor %}
-</section>
+    </section>
+{% endif %}


### PR DESCRIPTION
Moved the `named_individuals|length > 0` check to the named_individuals.html template, to avoid creating an empty section element. 

Fixes #113 