### PR TITLE
Simplistic multi-language support

### DIFF
--- a/pylode/cli.py
+++ b/pylode/cli.py
@@ -93,6 +93,13 @@ def main(args=None):
     )
 
     parser.add_argument(
+        "-l",
+        "--language",
+        help="The ISO 639 language code for the desired output language.",
+        default="en",
+    )
+
+    parser.add_argument(
         "-v",
         "--version",
         help="The version of this copy of pyLODE.",
@@ -120,14 +127,16 @@ def main(args=None):
                 input_data_file=args.inputfile,
                 outputformat=args.outputformat,
                 profile=args.profile,
-                include_css=include_css
+                include_css=include_css,
+                language=args.language,
             )
         elif args.url:
             h = MakeDocco(
                 input_uri=args.url,
                 outputformat=args.outputformat,
                 profile=args.profile,
-                include_css=include_css
+                include_css=include_css,
+                language=args.language,
             )
         else:
             # we have neither an input file or a URI supplied

--- a/pylode/common.py
+++ b/pylode/common.py
@@ -36,7 +36,7 @@ from .profiles import OntDoc, Prof, VocPub, PROFILES
 
 
 class MakeDocco:
-    def __init__(self, input_data_file=None, input_uri=None, data=None, outputformat="html", include_css=True, get_curies_online=False, profile="ontdoc"):
+    def __init__(self, input_data_file=None, input_uri=None, data=None, outputformat="html", include_css=True, get_curies_online=False, profile="ontdoc", language="en"):
         """This class receives all of the variables needed to specify how to make documentation from an input RDF source
 
         :param input_data_file: An RDF file
@@ -53,6 +53,8 @@ class MakeDocco:
         :type get_curies_online: boolean
         :param profile: When document profile, from a supported set, to use. Currently supported is "ontdoc" (profile of OWL) or "skosp" (profile of SKOS). See `list_profiles()` for full list of profiles.
         :type profile: string (one of "ontdoc", "skosp" or "prof")
+        :param language: ISO 639 code for the desired output language
+        :type language: string
         """
         self.profile_selected = profile
 
@@ -63,6 +65,7 @@ class MakeDocco:
 
         self.include_css = include_css
         self.get_curies_online = get_curies_online
+        self.language = language
 
         if profile not in PROFILES.keys():
             print("The profile you've selected, {}, is not recognised so the default profile, {} is being used. "
@@ -156,7 +159,7 @@ class MakeDocco:
                 self.source_info,
                 outputformat=self.outputformat,
                 include_css=self.include_css,
-                default_language="en",
+                default_language=self.language,
                 get_curies_online=self.get_curies_online
             )
         elif self.profile_selected == "vocpub":
@@ -165,7 +168,7 @@ class MakeDocco:
                 self.source_info,
                 outputformat=self.outputformat,
                 include_css=self.include_css,
-                default_language="en",
+                default_language=self.language,
                 get_curies_online=self.get_curies_online
             )
         else:
@@ -174,7 +177,7 @@ class MakeDocco:
                 self.source_info,
                 outputformat=self.outputformat,
                 include_css=self.include_css,
-                default_language="en",
+                default_language=self.language,
                 get_curies_online=self.get_curies_online
             )
 

--- a/pylode/profiles/base.py
+++ b/pylode/profiles/base.py
@@ -1,7 +1,7 @@
 import collections
 
 from jinja2 import Environment, FileSystemLoader
-from rdflib import SDO, SKOS, OWL, URIRef, RDF, PROF, Literal, XSD, Graph, Namespace, FOAF
+from rdflib import SDO, SKOS, OWL, URIRef, RDF, PROF, Literal, XSD, Graph, Namespace, FOAF, Graph
 
 import pylode.profiles.profile
 from pylode.common import TEMPLATES_DIR
@@ -14,13 +14,22 @@ class BaseProfile:
         self.default_language = default_language
         self.get_curies_online = get_curies_online
         self.default_namespace = None
-        self.G = g
+        self.G = self._filter_graph_by_language(g, default_language)
         self.source_info = source_info
         self.G.bind("sdo", SDO)
         self.G.bind("skos", SKOS)
         self.NAMESPACES = collections.OrderedDict()
         self.FIDS = {}
         self.METADATA = {}
+
+    def _filter_graph_by_language(self, g, language):
+        filtered = Graph()
+
+        for s, p, o in g:
+            if not type(o) is Literal or not o.language or o.language == language:
+                filtered.add((s, p, o))
+
+        return filtered
 
     def _load_template(self, template_file):
         return Environment(loader=FileSystemLoader(TEMPLATES_DIR)).get_template(template_file)


### PR DESCRIPTION
A pretty minimal approach to supporting multiple languages that filters out all literals that aren't in the specified language. There are some limitations though:
- There is no fallback language
- Literals without language tags may still clash with literals that do have a language set though. For example:
```
<ex:ontology>
  a owl:Ontology ;
  rdfs:label            "label a" ;
  rdfs:label            "label b"@en .
```
Perhaps we can simply add some additional logging that tells users which language is used, how many triples are used/discarded, how many subjects no longer have a label, ... Alternatively, we could have a 'preferred' and a 'fallback' graph, one with the statements in the preferred language, and  a fallback in english/without language tags. This approach might be more user friendly, but I'm not sure we should encourage partial translations. 

#18 