### PR TITLE
fix RDFLib/pyLODE#145 caused by RDFLib/rdflib#1183 (rdflib 6.0.0)

### DIFF
--- a/pylode/profiles/base.py
+++ b/pylode/profiles/base.py
@@ -464,7 +464,7 @@ class BaseProfile:
         from rdflib.plugin import register, Serializer
         register('json-ld', Serializer, 'rdflib_jsonld.serializer', 'JsonLDSerializer')
 
-        return g.serialize(format="json-ld").decode("utf-8")
+        return g.serialize(format="json-ld", encoding="utf-8")  # support >= rdflib 6.0.0 and ensure backwards compat (last python 2 release)
 
     def _make_agent_link(self, name, url=None, email=None, affiliation=None):
         if self.outputformat == "md":


### PR DESCRIPTION
Fix #145 for`AttributeError` of `serialize()`. With backwards compatibility for
rdflib==5.0.0, as its the last python 2 release and as long as pyLODE
might still support rdflib 5.0.0