### PR TITLE
Closes #146 owl:FunctionalProperty is ignored

### DIFF
--- a/pylode/profiles/ontdoc.py
+++ b/pylode/profiles/ontdoc.py
@@ -645,10 +645,10 @@ class OntDoc(BaseProfile):
         for prop in self.PROPERTIES.keys():
             s = URIRef(prop)
             # property type
-            if (s, RDF.type, OWL.ObjectProperty) in self.G:
-                self.PROPERTIES[prop]["prop_type"] = "op"
-            elif (s, RDF.type, OWL.FunctionalProperty) in self.G:
+            if (s, RDF.type, OWL.FunctionalProperty) in self.G:
                 self.PROPERTIES[prop]["prop_type"] = "fp"
+            elif (s, RDF.type, OWL.ObjectProperty) in self.G:
+                self.PROPERTIES[prop]["prop_type"] = "op"
             elif (s, RDF.type, OWL.DatatypeProperty) in self.G:
                 self.PROPERTIES[prop]["prop_type"] = "dp"
             elif (s, RDF.type, OWL.AnnotationProperty) in self.G:


### PR DESCRIPTION
A object property also can be a functional property.

https://www.w3.org/TR/2004/REC-owl-semantics-20040210/syntax.html#owl_ObjectProperty_syntax