### PR TITLE
use rdflib jsonld serializer?

### DIFF
--- a/pylode/profiles/base.py
+++ b/pylode/profiles/base.py
@@ -462,7 +462,7 @@ class BaseProfile:
 
         # make sure the json-ld serializer is registered
         from rdflib.plugin import register, Serializer
-        register('json-ld', Serializer, 'rdflib_jsonld.serializer', 'JsonLDSerializer')
+        register('json-ld', Serializer, 'rdflib.plugins.serializers.jsonld', 'JsonLDSerializer')
 
         return g.serialize(format="json-ld", encoding="utf-8")  # support >= rdflib 6.0.0 and ensure backwards compat (last python 2 release)
 


### PR DESCRIPTION
I get a `ModuleNotFoundError: No module named 'rdflib_jsonld.serializer'` from line 467 (`return g.serialize(format="json-ld", encoding="utf-8")` unless I make this edit to use the rdflib (6.0.2) serializer. This is with `rdflib-jsonld==0.6.2` installed.