### PR TITLE
fix: switch arg order in call to `cast`

### DIFF
--- a/pylode/utils.py
+++ b/pylode/utils.py
@@ -264,7 +264,7 @@ def load_ontology(ontology: Union[Graph, Path, str]) -> Graph:
                     input_format = "turtle"  # this will also cover n-triples
                 return Graph().parse(data=ontology, format=input_format)
         elif isinstance(ontology, Graph):
-            return cast(ontology, Graph)
+            return cast(Graph, ontology)
         elif isinstance(ontology, Path):
             return Graph().parse(ontology)
         else:


### PR DESCRIPTION
otherwise, load_ontology returns the Graph *class* rather than the `ontology` Graph *instance*.

this manifests downstream as a cryptic `AttributeError: 'URIRef' object has no attribute 'triples'` error when trying to initialize an `OntDoc` from a `Graph` instance.