### PR TITLE
Fixed broken path for external CSS file.

### DIFF
--- a/pylode/ontdoc.py
+++ b/pylode/ontdoc.py
@@ -288,7 +288,7 @@ class OntDoc:
             else:
                 link(href="pylode.css", rel="stylesheet", type="text/css")
                 shutil.copy(
-                    Path("pylode.css"),
+                    Path(__file__).parent / "pylode.css",
                     destination.parent / "pylode.css")
             link(
                 rel="icon",


### PR DESCRIPTION
When using `-c false` the css to be copied could not be found, because the path used was relative to the current work directory.