### PR TITLE
Poetry support for install of comand line pylode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ rdflib = "^6.1.1"
 Markdown = "^3.3.7"
 dominate = "^2.6.0"
 
+[tool.poetry.scripts]
+pylode = "pylode.cli:main"
+
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
 black = "^22.3.0"


### PR DESCRIPTION
Potentially Fixes #168. Migration to poetry to push to pypi broke the command line installation. Added command line configuration to the pyproject.toml which I think will solve the problem. I think the only way to test the solution is to push to pypi and see if the pylode command line tool is now generated.