### PR TITLE
pyLODE docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+COPY . ./
+COPY schema.ttl ./
+RUN pip3.10 install --no-cache-dir -r requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,18 @@ Basic Use
 This will produce the file ``minimal.html`` in this directory which should
 match exactly the file ``examples/minimal.html``.
 
+* as a docker container
+
+build the docker image
+::
+   docker build -t pylode:latest .
+
+copy the example directory, mount it to the countainer and run cli.py in the container
+::
+   docker  run  --mount 'type=bind,src=<ttl_directory>,target=/app/pylode/data' pylode:latest  python3.10 pylode/cli.py data/<ttl_file> -o data/<html_file>
+
+   Note: <ttl_directory> must be absolute 
+
 Module Use
 ^^^^^^^^^^
 


### PR DESCRIPTION
Add a dockerfile to build a docker image with pylode, which can be a basis to run pylode as a container. Instructions in the read me added to run docker image with a mounted directory for input/output files.