### PR TITLE
Fixes error loading ontology from rdflib.Graph

### DIFF
--- a/pylode/utils.py
+++ b/pylode/utils.py
@@ -267,7 +267,7 @@ def load_ontology(ontology: Union[Graph, Path, str]) -> Graph:
                     input_format = "turtle"  # this will also cover n-triples
                 return Graph().parse(data=ontology, format=input_format)
         elif isinstance(ontology, Graph):
-            return cast(ontology, Graph)
+            return cast(Graph, ontology)
         elif isinstance(ontology, Path):
             return Graph().parse(ontology)
         else:


### PR DESCRIPTION
Hi, I tried using this library in combination with `rdflib` (version `6.2.0`) and I found a bug, that occurs when you pass an instance of an `rdflib.Graph` into the constructor of `pylode.OntDoc`:

```python
import pylode
import rdflib

graph = rdflib.Graph()
graph.parse("https://akswnc7.informatik.uni-leipzig.de/dstreitmatter/archivo/bdi.si.ehu.es/bdi--ontologies--ExtruOnt--ExtruOnt/2020.12.14-144514/bdi--ontologies--ExtruOnt--ExtruOnt_type=parsed.ttl")

ontdoc = pylode.OntDoc(graph)
```
Which raises the error:

```
Traceback (most recent call last):
  File "/home/denis/workspace/Job/testarea/pylode_test/test_pylode.py", line 7, in <module>
    ontdoc = pylode.OntDoc(graph)
  File "/home/denis/workspace/Job/testarea/pylode_test/env/lib/python3.10/site-packages/pylode/ontdoc.py", line 104, in __init__
    self._ontdoc_inference(self.ont)
  File "/home/denis/workspace/Job/testarea/pylode_test/env/lib/python3.10/site-packages/pylode/ontdoc.py", line 154, in _ontdoc_inference
    for s_ in g.subjects(RDF.type, OWL.Class):
  File "/home/denis/workspace/Job/testarea/pylode_test/env/lib/python3.10/site-packages/rdflib/graph.py", line 746, in subjects
    for s, p, o in self.triples((None, predicate, object)):
AttributeError: 'URIRef' object has no attribute 'triples'
```

The problem was rather simple: The `cast` method was used in the wrong order, resulting in the wrong passed result type.