### PR TITLE
Fix broken link to pylode.css

### DIFF
--- a/pylode/profiles/ontpub.py
+++ b/pylode/profiles/ontpub.py
@@ -285,7 +285,7 @@ class OntPub:
             else:
                 link(href="pylode.css", rel="stylesheet", type="text/css")
                 shutil.copy(
-                    Path(__file__).parent / "pylode.css",
+                    Path(__file__).parent.parent / "pylode.css",
                     destination.parent / "pylode.css",
                 )
             link(


### PR DESCRIPTION
Related to #163.

Apparently the file moved, which caused #183.

The following did not work without the fix, but does work with the fix:

```bash
python -m pylode ./examples/ontpub/minimal.ttl -o index.html --css false
```