### PR TITLE
Fix typo to rdfs:label

### DIFF
--- a/pylode/profiles/ontpub.py
+++ b/pylode/profiles/ontpub.py
@@ -119,7 +119,7 @@ class OntPub:
         if t is None:
             raise PylodeError(
                 "You MUST supply a title property "
-                "(dcterms:title, rdf:label or sdo:name) for your ontology"
+                "(dcterms:title, rdfs:label or sdo:name) for your ontology"
             )
         self.doc = dominate.document(title=t)
 

--- a/pylode/profiles/vocpub.py
+++ b/pylode/profiles/vocpub.py
@@ -122,7 +122,7 @@ class VocPub:
         if t is None:
             raise PylodeError(
                 "You MUST supply a title property "
-                "(dcterms:title, rdf:label or sdo:name) for your ontology"
+                "(dcterms:title, rdfs:label or sdo:name) for your ontology"
             )
         self.doc = dominate.document(title=t)
 


### PR DESCRIPTION
Some error messages instruct the user to add a title. They suggest to add a "rdf:label" property. I think a more common namespace prefix for the[ RDF Schema label property](https://www.w3.org/TR/rdf12-schema/#ch_label) is rdfs, so I changed the error string to mention an "rdfs:label" property instead.