### PR TITLE
Refactoring Agent display

### DIFF
--- a/pylode/profiles/ontpub.py
+++ b/pylode/profiles/ontpub.py
@@ -276,7 +276,7 @@ class OntPub:
     def _make_head(
         self, schema_org: Graph, include_css: bool = True, destination: Path = None
     ):
-        """Healper function for make_html(). Makes <head>???</head> content"""
+        """Helper function for make_html(). Makes <head>???</head> content"""
         with self.doc.head:
             # use standard pyLODE stylesheet
             if include_css:
@@ -313,7 +313,7 @@ class OntPub:
             )
 
     def _make_body(self):
-        """Healper function for make_html(). Makes <body>???</body> content.
+        """Helper function for make_html(). Makes <body>???</body> content.
 
         Just calls other helper functions in order"""
         make_pylode_logo(

--- a/pylode/pylode.css
+++ b/pylode/pylode.css
@@ -60,6 +60,9 @@
         #classes ul li {
             margin-left: -40px;
         }
+        #metadata dd p {
+          margin: 0;
+        }
 
         ul.hlist {
             list-style-type: none;

--- a/pylode/rdf_elements.py
+++ b/pylode/rdf_elements.py
@@ -82,7 +82,7 @@ PROP_PROPS = [
 
 # properties for Agents
 AGENT_PROPS = [
-    SDO.name,
+    DCTERMS.title,
     SDO.affiliation,
     SDO.identifier,
     SDO.email,

--- a/pylode/utils.py
+++ b/pylode/utils.py
@@ -493,7 +493,7 @@ def rdf_obj_html(
 
                 for p_, o_ in ont___.predicate_objects(obj___):
                     if p_ in AGENT_PROPS:
-                        if p_ == SDO.name:
+                        if p_ == DCTERMS.title:
                             name_ = str(o_)
                         elif p_ == SDO.url:
                             url_ = str(o_)
@@ -507,19 +507,17 @@ def rdf_obj_html(
                 else:
                     if "http" in obj___:
                         sp_.appendChild(em(" of ", a(obj___, href=obj___)))
+                    else:
+                        sp_.appendChild(em(" of ", obj___))
                 return sp_
 
-            if isinstance(obj__, Literal):
-                return span(str(obj__))
-            honorific_prefix = None
-            name = None
-            identifier = None
-            orcid = None
-            orcid_logo = """
+            def _orcid_logo_svg( id ):
+                id = id if ('http' in id) else f"https://orcid.org/{id}"
+                return f"""
                     <svg width="15px" height="15px" viewBox="0 0 72 72" version="1.1"
                         xmlns="http://www.w3.org/2000/svg"
                         xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <title>Orcid logo</title>
+                        <title>{id}</title>
                         <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                             <g id="hero" transform="translate(-924.000000, -72.000000)" fill-rule="nonzero">
                                 <g id="Group-4">
@@ -535,6 +533,13 @@ def rdf_obj_html(
                             </g>
                         </g>
                     </svg>"""
+
+            if isinstance(obj__, Literal):
+                return span(str(obj__))
+            honorific_prefix = None
+            name = None
+            identifier = None
+            orcid = None
             url = None
             email = None
             affiliation = None
@@ -544,7 +549,7 @@ def rdf_obj_html(
 
             for px, o in ont__.predicate_objects(obj__):
                 if px in AGENT_PROPS:
-                    if px == SDO.name:
+                    if px == DCTERMS.title:
                         name = str(o)
                     elif px == SDO.honorificPrefix:
                         honorific_prefix = str(o)
@@ -572,15 +577,14 @@ def rdf_obj_html(
 
                 if orcid:
                     if "orcid.org" in obj__:
-                        sp.appendChild(a(raw(orcid_logo), href=obj__))
+                        sp.appendChild(a(raw(_orcid_logo_svg(obj__)), href=obj__))
                     else:
-                        sp.appendChild(a(raw(orcid_logo), href=identifier))
+                        sp.appendChild(a(raw(_orcid_logo_svg(identifier)), href=identifier))
                 elif identifier is not None:
                     sp.appendChild(a(identifier, href=identifier))
                 if email is not None:
                     email = email.replace("mailto:", "")
                     sp.appendChild(span("(", a(email, href="mailto:" + email), " )"))
-
                 if affiliation is not None:
                     sp.appendChild(_affiliation_html(ont__, affiliation))
             else:
@@ -684,6 +688,7 @@ def rdf_obj_html(
                 return _restriction_html(ont__, obj__, ns__)
             else:  # (obj, RDF.type, OWL.Class) in ont:  # Set Class
                 return _setclass_html(ont__, obj__, back_onts__, ns__, fids__)
+
 
         if isinstance(obj_, Tuple) or isinstance(obj_, URIRef):
             ret = _hyperlink_html(


### PR DESCRIPTION
while using pyLODE, I had some issues with properly showing contributors names.

I investigated a little and found the following:
 names are normalized to use `dcterms:title` [here (ontpub)](https://github.com/RDFLib/pyLODE/blob/master/pylode/profiles/ontpub.py#L167) and [here (vocpub)](https://github.com/RDFLib/pyLODE/blob/master/pylode/profiles/vocpub.py#L170)

however, when serializing for html [here](https://github.com/RDFLib/pyLODE/blob/master/pylode/utils.py#L547) and [here](https://github.com/RDFLib/pyLODE/blob/master/pylode/utils.py#L496) only `sdo:name` is used.

in the pull request I changed that to use the canonical `dcterms:title` instead.

I also made minor changes to the formatting:
* I changed the CSS for the metadata display a little to make it more compact
* in the ORCID icons, I use the actual URL as a title and not the generic `Orcid logo` as before