### PR TITLE
Adding namespace propagations to render original namespace prefixes RDFLib/pyLODE#244

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,4 +118,7 @@ output_files/
 
 pylode/_version.py
 
-.pickle
+*.pickle
+
+actual.html
+expected.html

--- a/pylode/profiles/supermodel/query/__init__.py
+++ b/pylode/profiles/supermodel/query/__init__.py
@@ -404,6 +404,11 @@ class Query:
         self.root_profile_iri = get_root_profile_iri(graph)
         self.db = load_profiles(self.root_profile_iri, graph.serialize())
         self.graph = self.db.root_graph
+
+        # We need this to see the prefixes in the loaded file
+        for prefix, namespace in graph.namespace_manager.namespaces():
+            self.graph.namespace_manager.bind(prefix, namespace, override=True)
+
         self.debug = True if (None, LODE.debug, None) in self.db.config_graph else False
 
         # An IRI index of classes that 'exist' within this documentation.

--- a/pylode/utils.py
+++ b/pylode/utils.py
@@ -293,6 +293,11 @@ def sort_ontology(ont_orig: Graph) -> Graph:
     trpls = ont_orig.triples((None, None, None))
     trpls_srt = sorted(trpls)
     ont_sorted = Graph(bind_namespaces="core")
+
+    # Recover the namespaces
+    for prefix, namespace in ont_orig.namespace_manager.namespaces():
+        ont_sorted.namespace_manager.bind(prefix, namespace, override=True)
+
     for trpl in trpls_srt:
         ont_sorted.add(trpl)
     return ont_sorted


### PR DESCRIPTION
This fixes the problem of namespaces in the original ontology file rendered like `ns1:`, `ns2:` by the super mode. This is due to a couple of points, where the original graph created from the file loading is copied into a new graph, without considering the original namespaces.