### PR TITLE
Updated utils.py to include the class name for in restrictions (and within the same line)

### DIFF
--- a/pylode/utils.py
+++ b/pylode/utils.py
@@ -630,6 +630,8 @@ def rdf_obj_html(
                 if px != RDF.type:
                     if px == OWL.onProperty:
                         prop = _hyperlink_html(ont__, back_onts_, ns__, o, fids_)
+                    elif px == OWL.onClass:
+                        cls = _hyperlink_html(ont__, back_onts_, ns__, o, fids_, OWL.Class)
                     elif px in RESTRICTION_TYPES + OWL_SET_TYPES:
                         if px in [
                             OWL.minCardinality,
@@ -676,10 +678,12 @@ def rdf_obj_html(
                                 ),
                             )
 
-            restriction = span(prop, card, br()) if card is not None else prop
-            restriction = (
-                span(restriction, cls, br()) if cls is not None else restriction
-            )
+            if card is not None and cls is not None:
+                restriction = span(prop, card, cls, br())
+            elif card is not None:
+                restriction = span(prop, card, br())
+            else:
+                restriction = prop
 
             return span(restriction) if restriction is not None else "None"
 

--- a/pylode/utils.py
+++ b/pylode/utils.py
@@ -630,6 +630,7 @@ def rdf_obj_html(
                 if px != RDF.type:
                     if px == OWL.onProperty:
                         prop = _hyperlink_html(ont__, back_onts_, ns__, o, fids_)
+                    #Added the onClass restriction otherwise the class name is ignored in the HTML output. 
                     elif px == OWL.onClass:
                         cls = _hyperlink_html(ont__, back_onts_, ns__, o, fids_, OWL.Class)
                     elif px in RESTRICTION_TYPES + OWL_SET_TYPES:
@@ -678,6 +679,7 @@ def rdf_obj_html(
                                 ),
                             )
 
+            #Combined the check for card and cls so that only one br is added.
             if card is not None and cls is not None:
                 restriction = span(prop, card, cls, br())
             elif card is not None:


### PR DESCRIPTION
Hi,

Thanks for creating this library. It is very useful. I came across two issues and included a fix for them as I explained below. All 20 tests run successfully. However, please double check the changes as I'm not an expert on this library, and feel free to fix the issues differently according to your own preferred solution.

Details:
When the HTML version is created,  the class names for restrictions are not added. For example

"Pizza hasTopping min 1 PizzaToppping" becomes "Pizza hasTopping min 1 " in the HTML output without the current fix.

Second part of the fix makes sure the class name stays on the same line.
For example:
"Pizza hasTopping min 1 PizzaToppping" is rendered in two lines as follows without the fix included.

"Pizza hasTopping min 1 
PizzaToppping"



