### PR TITLE
GH-175: Add support for EqivalentProperty

### DIFF
--- a/pylode/rdf_elements.py
+++ b/pylode/rdf_elements.py
@@ -66,6 +66,7 @@ PROP_PROPS = [
     SKOS.note,
     RDFS.subPropertyOf,
     ONTPUB.superPropertyOf,
+    OWL.equivalentProperty,
     RDFS.domain,
     SDO.domainIncludes,
     RDFS.range,

--- a/tests/data/equivalentproperty.ttl
+++ b/tests/data/equivalentproperty.ttl
@@ -1,0 +1,15 @@
+PREFIX : <https://example.com/ep/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX sdo: <https://schema.org/>
+
+<https://example.com/ep> a owl:Ontology ;
+    dcterms:title "EquivalentProperty Test" .
+
+:familyName a owl:DatatypeProperty ;
+    rdfs:label "family name" ;
+    owl:equivalentProperty sdo:familyName , :surname .
+
+:surname a owl:DatatypeProperty ;
+    rdfs:label "surname" .

--- a/tests/test_equivalentproperty.py
+++ b/tests/test_equivalentproperty.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from pylode.profiles import OntPub
+from pylode.utils import de_space_html
+
+current_dir = Path(__file__).parent
+
+
+def test_equivalentproperty():
+    """owl:equivalentProperty renders on properties (issue #175)"""
+    html = OntPub(current_dir / "data" / "equivalentproperty.ttl").make_html()
+
+    assert (
+        de_space_html(
+            """
+            <a class="hover_property" href="http://www.w3.org/2002/07/owl#equivalentProperty"
+            title="The property that determines that two given properties are equivalent.
+            Defined in The OWL 2 Schema vocabulary (OWL 2)">Equivalent Property</a>
+            """
+        )
+        in de_space_html(html)
+    ), "equivalentProperty header not rendered/labeled"
+
+    # in-ontology target links to its anchor; external target links out
+    assert '<a href="#surname">' in html, "internal equivalent property not anchor-linked"
+    assert "schema.org/familyName" in html, "external equivalent property not rendered"


### PR DESCRIPTION
Fixes #175 

After #268, this one seemed pretty straightforward. The gist is that the rendering engine already supports this level of property, so it was a matter of a 1 line change to add it. The rest are tests.


I've attached a screenshot of what the rendering looks like after this PR, along with a test HTML file.
<img width="1532" height="726" alt="Screenshot 2026-08-14 at 10 29 10 AM" src="https://github.com/user-attachments/assets/9d51945b-321c-45d7-aaa7-413be84de213" />



[equivprop-test.html](https://github.com/user-attachments/files/31080959/equivprop-test.html)
