### PR TITLE
GH-223: Add support for symmetric properties

### DIFF
--- a/pylode/profiles/ontpub.py
+++ b/pylode/profiles/ontpub.py
@@ -73,14 +73,10 @@ class OntPub:
         for s_ in g.subjects(RDF.type, RDFS.Class):
             g.add((s_, RDF.type, OWL.Class))
 
-        # # property types
-        # for s_ in chain(
-        #     g.subjects(RDF.type, OWL.ObjectProperty),
-        #     g.subjects(RDF.type, OWL.FunctionalProperty),
-        #     g.subjects(RDF.type, OWL.DatatypeProperty),
-        #     g.subjects(RDF.type, OWL.AnnotationProperty),
-        # ):
-        #     g.add((s_, RDF.type, RDF.Property))
+        # property types
+        for prop_type in OBJECT_PROPERTY_SUBCLASSES:
+            for s_ in g.subjects(RDF.type, prop_type):
+                g.add((s_, RDF.type, OWL.ObjectProperty))
 
         # name
         for s_, o in chain(

--- a/pylode/profiles/supermodel/query/__init__.py
+++ b/pylode/profiles/supermodel/query/__init__.py
@@ -24,6 +24,7 @@ from rdflib.namespace import (
 )
 
 from pylode.profiles.supermodel.loader import load_profiles
+from pylode.rdf_elements import OBJECT_PROPERTY_SUBCLASSES
 from pylode.profiles.supermodel.model import (
     Class,
     CodedProperty,
@@ -262,7 +263,11 @@ def get_rdf_property(iri, graph, db: Dataset) -> RDFProperty:
 def get_rdf_properties(
     rdf_property_type: URIRef, graph: Graph, db: Dataset
 ) -> list[RDFProperty]:
-    property_iris = graph.subjects(RDF.type, rdf_property_type)
+    property_iris = set(graph.subjects(RDF.type, rdf_property_type))
+    if rdf_property_type == OWL.ObjectProperty:
+        # OWL 2 declares these to be subclasses of owl:ObjectProperty
+        for prop_type in OBJECT_PROPERTY_SUBCLASSES:
+            property_iris.update(graph.subjects(RDF.type, prop_type))
     properties = []
     for property_iri in property_iris:
         prop = get_rdf_property(property_iri, graph, db)

--- a/pylode/rdf_elements.py
+++ b/pylode/rdf_elements.py
@@ -100,6 +100,17 @@ RESTRICTION_TYPES = [
 
 OWL_SET_TYPES = [OWL.unionOf, OWL.intersectionOf]
 
+# OWL 2 defines these property characteristic classes as
+# rdfs:subClassOf owl:ObjectProperty
+OBJECT_PROPERTY_SUBCLASSES = [
+    OWL.SymmetricProperty,
+    OWL.AsymmetricProperty,
+    OWL.TransitiveProperty,
+    OWL.ReflexiveProperty,
+    OWL.IrreflexiveProperty,
+    OWL.InverseFunctionalProperty,
+]
+
 DATATYPE_CARDINALITIES = {
     XSD.minInclusive: ">=",
     XSD.minExclusive: ">",

--- a/tests/data/symmetric.ttl
+++ b/tests/data/symmetric.ttl
@@ -1,0 +1,18 @@
+PREFIX : <https://example.com/sym/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+<https://example.com/sym> a owl:Ontology ;
+    dcterms:title "Symmetric Property Test" .
+
+# typical: dual-typed
+:adjacentTo a owl:ObjectProperty , owl:SymmetricProperty ;
+    rdfs:label "adjacent to" .
+
+# only typed symmetric
+:touches a owl:SymmetricProperty ;
+    rdfs:label "touches" .
+
+:regularProp a owl:ObjectProperty ;
+    rdfs:label "regular prop" .

--- a/tests/test_symmetric.py
+++ b/tests/test_symmetric.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from pylode.profiles import OntPub
+
+current_dir = Path(__file__).parent
+
+
+def test_symmetric_property():
+    """Properties typed only owl:SymmetricProperty (or other OWL 2 property
+    characteristics) are documented as object properties"""
+    html = OntPub(current_dir / "data" / "symmetric.ttl").make_html()
+    toc = html[html.find('id="toc"'):]
+
+    # dual-typed and characteristic-only properties both render...
+    assert 'id="adjacentTo"' in html
+    assert 'id="touches"' in html, "SymmetricProperty-only property not in body"
+
+    # ...and both appear in the ToC
+    assert '"#adjacentTo"' in toc
+    assert '"#touches"' in toc, "SymmetricProperty-only property not in ToC"


### PR DESCRIPTION
Fixes #223 

I was hoping this was going to be as straight forward as #269, but I hit a snag. It looks like there might have been thinking about rendering this before, from [here](https://github.com/RDFLib/pyLODE/compare/master...ThomasThelen:pyLODE:feature_symmetric_property?expand=1#diff-980ca01341ac12d5574f20d3199ee374e3e5fa093a18437ec0c12d43964b271aL77). This PR effectively continues/finishes off that work by pulling the property types out into their own list and conditionally adding them to the rdflib graph that gets rendered.