### PR TITLE
GH-220: Display equivalentClass in super model mode

### DIFF
--- a/pylode/profiles/supermodel/html.py
+++ b/pylode/profiles/supermodel/html.py
@@ -474,6 +474,31 @@ class Supermodel:
                                         else:
                                             external_link(subclass.name, subclass.iri)
 
+            if cls.equivalent_classes:
+                h5("Equivalent to")
+                with div(_class="sect5"):
+                    with div(_class="ulist"):
+                        with ul():
+                            for equivalent_class in cls.equivalent_classes:
+                                with li():
+                                    with p():
+                                        if (
+                                            equivalent_class.iri
+                                            in self.query.class_index
+                                        ):
+                                            fragment = make_html_fragment(
+                                                CLASS_STRING.format(equivalent_class.iri)
+                                            )
+                                            a(
+                                                equivalent_class.name,
+                                                href=f"#{fragment}",
+                                            )
+                                        else:
+                                            external_link(
+                                                equivalent_class.name,
+                                                equivalent_class.iri,
+                                            )
+
             if cls.properties:
                 h5("Properties")
                 self._make_component_model_class_properties(cls.properties)

--- a/pylode/profiles/supermodel/model.py
+++ b/pylode/profiles/supermodel/model.py
@@ -171,6 +171,7 @@ class Class:
     description: str = None
     subclasses: list["Class"] = field(default_factory=list)
     superclasses: list["Class"] = field(default_factory=list)
+    equivalent_classes: list["Class"] = field(default_factory=list)
     properties: dict[str, list[Property]] = field(default_factory=dict)
     examples: list[MediaObject] = field(default_factory=list)
     notes: list[Note] = field(default_factory=list)

--- a/pylode/profiles/supermodel/query/__init__.py
+++ b/pylode/profiles/supermodel/query/__init__.py
@@ -929,6 +929,32 @@ class Query:
             key=lambda x: x.name,
         )
 
+    def get_equivalent_classes(
+        self, iri: URIRef, graph: Graph, ignored_classes: list[URIRef]
+    ) -> list[Class]:
+        """Extract the equivalent classes of a class and return the supermodel
+        representation.
+
+        Args:
+            iri: The IRI of the class whose equivalent classes are being resolved.
+            graph: The profile graph to read the owl:equivalentClass statements from.
+            ignored_classes: Class IRIs to exclude from the result.
+
+        Return:
+            A list of he super model class representations, sorted by name.
+        """
+        equivalent_classes = filter(
+            lambda x: x not in ignored_classes and isinstance(x, URIRef),
+            list(graph.objects(iri, OWL.equivalentClass)),
+        )
+        return sorted(
+            [
+                Class(iri=equivalent_class, name=get_name(equivalent_class, graph, self.db))
+                for equivalent_class in equivalent_classes
+            ],
+            key=lambda x: x.name,
+        )
+
     def get_component_model_class(
         self, iri: URIRef, graph: Graph, ignored_classes: list[URIRef]
     ):
@@ -938,6 +964,7 @@ class Query:
         # TODO: Add memoization to remove the need to recalculate the same classes.
         #       Reuse self.class_index or something similar for memoize data structure.
         superclasses = self.get_superclasses(iri, graph, ignored_classes)
+        equivalent_classes = self.get_equivalent_classes(iri, graph, ignored_classes)
         properties = self.get_component_model_class_properties(iri, ignored_classes)
 
         def _merge_superclass_properties(superclasses: list[Class]):
@@ -968,6 +995,7 @@ class Query:
             description=descriptions,
             subclasses=subclasses,
             superclasses=superclasses,
+            equivalent_classes=equivalent_classes,
             properties=properties,
             examples=examples,
             notes=notes,

--- a/tests/data/supermodel.ttl
+++ b/tests/data/supermodel.ttl
@@ -1,0 +1,18 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ex: <http://example.com/ont/> .
+
+ex: a owl:Ontology ;
+    dcterms:title "Supermodel Test Ontology" ;
+    dcterms:description "A minimal ontology used in the unit tests for the supermodel profile." .
+
+# ex:Person is equivalent to ex:Human (another class documented in this same
+# ontology, so the rendered link must be an in-page fragment) and to the
+# external foaf:Agent (which must render as an external link).
+ex:Person a owl:Class ;
+    rdfs:label "Person" ;
+    owl:equivalentClass ex:Human, <http://xmlns.com/foaf/0.1/Agent> .
+
+ex:Human a owl:Class ;
+    rdfs:label "Human" .

--- a/tests/test_supermodel.py
+++ b/tests/test_supermodel.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path().parent.parent.resolve() / "pylode"))
+import pytest
+
+from pylode.profiles.supermodel.html import Supermodel
+from pylode.utils import de_space_html
+
+current_dir = Path(__file__).parent
+
+
+@pytest.fixture(scope="session")
+def fix_html():
+    sm = Supermodel(current_dir / "data" / "supermodel.ttl")
+    return sm.make_html()
+
+
+def test_equivalent_class_section_rendered(fix_html):
+    """owl:equivalentClass must be displayed in supermodel mode."""
+    assert "Equivalent to" in de_space_html(fix_html)
+
+
+def test_equivalent_class_internal_link(fix_html):
+    """An equivalent class documented in the same ontology links though a
+    link fragment whose target is that class's heading id."""
+    html = de_space_html(fix_html)
+    assert '<a href="#http://example.com/ont/Human">Human</a>' in html
+
+
+def test_equivalent_class_external_link(fix_html):
+    """An equivalent class outside the ontology renders as an external link."""
+    assert 'href="http://xmlns.com/foaf/0.1/Agent"' in fix_html


### PR DESCRIPTION
Fixes #220 
Disclaimer: I've never used or looked at documentation generated by the super model mode prior to working on this issue, but saw it referenced in a few tickets and was curious.

The gist is that `OWL.equivalentClass` wasn't being parsed into the intermediate representation (the one that sits between the ontology and the HTML). There also wasn't HTML for equivalent classes.

This PR adds the logic to the query module for parsing out the equivalent classes and a UI element to present it. The UI changes looks pretty similar to the rest of the existing code. The new code in the query file executes, returning the list of classes, which the UI then iterates over.


**UI Demo**

<img width="1721" height="873" alt="Screenshot 2026-08-14 at 10 28 55 PM" src="https://github.com/user-attachments/assets/d327703c-80c5-4e21-9063-cac848ce509c" />


[supermodel_test.html](https://github.com/user-attachments/files/31095030/supermodel_test.html)
